### PR TITLE
feat: add compatibility with yarn pnp esm

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -78,10 +78,10 @@
       "description": "Only compile",
       "steps": [
         {
-          "exec": "yarn link && cd ./test/test-app && yarn link cloudy-node"
+          "exec": "tsc --build"
         },
         {
-          "exec": "tsc --build"
+          "exec": "yarn link && cd ./test/test-app && yarn link cloudy-node"
         }
       ]
     },

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -35,7 +35,7 @@ const project = new typescript.TypeScriptProject({
 for (const tsconfig of [project.tsconfig, project.tsconfigDev]) {
   tsconfig.file.addOverride("compilerOptions.lib", ["ES2020"]);
   tsconfig.file.addOverride("compilerOptions.target", "ES2020");
-  tsconfig.file.addOverride("compilerOptions.module", "ES2020");
+  tsconfig.file.addOverride("compilerOptions.module", "CommonJS");
   tsconfig.file.addOverride("compilerOptions.moduleResolution", "node");
 }
 project.addDevDeps("@types/node@^14.0.0");

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -1,4 +1,4 @@
-import { typescript, github } from "projen";
+const { typescript, github } = require("projen");
 
 const project = new typescript.TypeScriptProject({
   defaultReleaseBranch: "main",
@@ -40,7 +40,6 @@ for (const tsconfig of [project.tsconfig, project.tsconfigDev]) {
 }
 project.addDevDeps("@types/node@^14.0.0");
 project.addFields({
-  type: "module",
   exports: {
     ".": {
       import: `./lib/index.js`,
@@ -49,7 +48,7 @@ project.addFields({
   },
 });
 
-project.compileTask.prependExec(
+project.compileTask.exec(
   `yarn link && cd ./test/test-app && yarn link ${project.package.packageName}`
 );
 project.testTask.prependExec("cd ./test/test-app && yarn");

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     }
   },
   "types": "lib/index.d.ts",
-  "type": "module",
   "exports": {
     ".": {
       "import": "./lib/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,8 @@
 import spawn from "cross-spawn";
 
 const argv = process.argv.slice(2);
-const path = "cloudy-node";
+// const path = "cloudy-node";
+const path = `file:${__dirname}/index.js`;
 process.exit(
   spawn.sync("node", ["--loader", path, ...argv], { stdio: "inherit" })
     .status ?? 0

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -9,7 +9,7 @@
     "lib": [
       "ES2020"
     ],
-    "module": "ES2020",
+    "module": "CommonJS",
     "noEmitOnError": false,
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "lib": [
       "ES2020"
     ],
-    "module": "ES2020",
+    "module": "CommonJS",
     "noEmitOnError": false,
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,


### PR DESCRIPTION
In order for `cloudy-node` to work with Yarn PNP + ESM, we have to provide a CommonJS module. When consuming `cloudy-node` using that environment, we also need to use `yarn unplug cloudy-node`.